### PR TITLE
Performance boost

### DIFF
--- a/components/it8951e/display.py
+++ b/components/it8951e/display.py
@@ -14,6 +14,7 @@ from esphome.const import (
     CONF_LAMBDA,
     CONF_MODEL,
     CONF_REVERSED,
+    CONF_SLEEP_WHEN_DONE,
 )
 
 DEPENDENCIES = ['spi']
@@ -46,6 +47,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_MODEL, default="M5EPD"): cv.enum(
                 MODELS, upper=True, space="_"
             ),
+            cv.Optional(CONF_SLEEP_WHEN_DONE, default=True): cv.boolean,
         }
     )
     .extend(cv.polling_component_schema("1s"))
@@ -101,3 +103,5 @@ async def to_code(config):
         cg.add(var.set_reversed(config[CONF_REVERSED]))
     if CONF_RESET_DURATION in config:
         cg.add(var.set_reset_duration(config[CONF_RESET_DURATION]))
+    if CONF_SLEEP_WHEN_DONE in config:
+        cg.add(var.set_sleep_when_done(config[CONF_SLEEP_WHEN_DONE]))

--- a/components/it8951e/it8951e.h
+++ b/components/it8951e/it8951e.h
@@ -97,8 +97,8 @@ shown in Figure 1. The use of a white image in the transition from 4-bit to
 
   struct IT8951DevInfo_s
   {
-      uint16_t usPanelW;
-      uint16_t usPanelH;
+      int usPanelW;
+      int usPanelH;
       uint16_t usImgBufAddrL;
       uint16_t usImgBufAddrH;
       char usFWVersion[16];
@@ -129,7 +129,7 @@ shown in Figure 1. The use of a white image in the transition from 4-bit to
 
   void set_reversed(bool reversed) { this->reversed_ = reversed; }
   void set_reset_duration(uint32_t reset_duration) { this->reset_duration_ = reset_duration; }
-  void set_model(it8951eModel model) { this->model_ = model; }
+  void set_model(it8951eModel model);
   void set_sleep_when_done(bool sleep_when_done) { this->sleep_when_done_ = sleep_when_done; }
 
   void setup() override;
@@ -144,9 +144,9 @@ shown in Figure 1. The use of a white image in the transition from 4-bit to
  protected:
   void draw_absolute_pixel_internal(int x, int y, Color color) override;
 
-  int get_width_internal() override;
+  int get_width_internal() override { return usPanelW_; };
 
-  int get_height_internal() override;
+  int get_height_internal() override { return usPanelH_; };
 
   uint32_t get_buffer_length_();
 
@@ -165,16 +165,18 @@ shown in Figure 1. The use of a white image in the transition from 4-bit to
 
   void get_device_info(struct IT8951DevInfo_s *info);
 
-  uint32_t max_x = 0;
-  uint32_t max_y = 0;
-  uint32_t min_x = 960;
-  uint32_t min_y = 540;
-  uint16_t m_endian_type, m_pix_bpp;
-
+  int max_x = 0;
+  int max_y = 0;
+  int min_x = 960;
+  int min_y = 540;
+  uint16_t m_endian_type = 0;
+  uint16_t m_pix_bpp = 0;
 
   GPIOPin *reset_pin_{nullptr};
   GPIOPin *busy_pin_{nullptr};
 
+  int usPanelW_{0};
+  int usPanelH_{0};
   bool reversed_{false};
   uint32_t reset_duration_{100};
   bool sleep_when_done_{true}; // If true, the display will go to sleep after each update

--- a/components/it8951e/it8951e.h
+++ b/components/it8951e/it8951e.h
@@ -130,6 +130,7 @@ shown in Figure 1. The use of a white image in the transition from 4-bit to
   void set_reversed(bool reversed) { this->reversed_ = reversed; }
   void set_reset_duration(uint32_t reset_duration) { this->reset_duration_ = reset_duration; }
   void set_model(it8951eModel model) { this->model_ = model; }
+  void set_sleep_when_done(bool sleep_when_done) { this->sleep_when_done_ = sleep_when_done; }
 
   void setup() override;
   void update() override;
@@ -162,7 +163,6 @@ shown in Figure 1. The use of a white image in the transition from 4-bit to
     display::DisplayType::DISPLAY_TYPE_GRAYSCALE // .displayType (M5EPD supports 16 gray scale levels)
   };
 
-  uint8_t *should_write_buffer_{nullptr};
   void get_device_info(struct IT8951DevInfo_s *info);
 
   uint32_t max_x = 0;
@@ -175,14 +175,17 @@ shown in Figure 1. The use of a white image in the transition from 4-bit to
   GPIOPin *reset_pin_{nullptr};
   GPIOPin *busy_pin_{nullptr};
 
-  bool reversed_ = false;
+  bool reversed_{false};
   uint32_t reset_duration_{100};
+  bool sleep_when_done_{true}; // If true, the display will go to sleep after each update
   enum it8951eModel model_{it8951eModel::M5EPD};
 
   void reset(void);
 
-  void wait_busy(uint32_t timeout = 30);
-  void check_busy(uint32_t timeout = 30);
+  /* 1000ms timeout because I've seen it take up to 750ms (and ~310ms on average)
+   * Mostly for screen sleep and run commands */
+  void wait_busy(uint32_t timeout = 1000);
+  void check_busy(uint32_t timeout = 1000);
 
   uint16_t get_vcom();
   void set_vcom(uint16_t vcom);


### PR DESCRIPTION
Rewrite of the SPI communication to send buffer in one command, instead of one for 2 pixels.
Plus other optimisations.

This results in x2 performance boost, but there is still ~700ms writing to the buffer memory and about the same time for the SPI transfer.

Writing to the buffer memory can be massively improved by not refreshing the watchdog timer at every pixel draw. But this needs a modification in the ESPHome [DisplayBuffer](https://github.com/esphome/esphome/blob/dev/esphome/components/display/display_buffer.cpp#L68) class.

`sleep_when_done` can be configured to `false` for an extra 200ms boost, but the display will consume more power.