### PR TITLE
Fix compilation error: has no member named 'partial_updating_';

### DIFF
--- a/components/it8951e/it8951e.cpp
+++ b/components/it8951e/it8951e.cpp
@@ -469,7 +469,7 @@ void IT8951ESensor::dump_config() {
         "  Sleep when done: %s\n"
         "  Partial Updating: %s\n"
         "  Full Update Every: %u",
-        YESNO(this->sleep_when_done_), YESNO(this->partial_updating_), this->full_update_every_);
+        YESNO(this->sleep_when_done_), YESNO(this->full_update_every_ > 0), this->full_update_every_);
 }
 
 }  // namespace it8951e


### PR DESCRIPTION
I kept getting this error upon compilation and saw this slight issue in the log line. Since there is no on off setting for partial updates I assumed it should be the `full update every` option for the log line.

This compiles but I have not been able to test it on a display yet.

```
Compiling .pioenvs/test-screen/src/esphome/components/it8951e/it8951e.cpp.o
In file included from src/esphome/components/it8951e/it8951e.cpp:1:
src/esphome/components/it8951e/it8951e.cpp: In member function 'virtual void esphome::it8951e::IT8951ESensor::dump_config()':
src/esphome/components/it8951e/it8951e.cpp:472:52: error: 'class esphome::it8951e::IT8951ESensor' has no member named 'partial_updating_'; did you mean 'partial_update_'?
  472 |         YESNO(this->sleep_when_done_), YESNO(this->partial_updating_), this->full_update_every_);
      |                                                    ^~~~~~~~~~~~~~~~~
src/esphome/core/log.h:99:101: note: in definition of macro 'esph_log_config'
   99 |   ::esphome::esp_log_printf_(ESPHOME_LOG_LEVEL_CONFIG, tag, __LINE__, ESPHOME_LOG_FORMAT(format), ##__VA_ARGS__)
      |                                                                                                     ^~~~~~~~~~~
src/esphome/components/it8951e/it8951e.cpp:468:5: note: in expansion of macro 'ESP_LOGCONFIG'
  468 |     ESP_LOGCONFIG(TAG,
      |     ^~~~~~~~~~~~~
src/esphome/components/it8951e/it8951e.cpp:472:40: note: in expansion of macro 'YESNO'
  472 |         YESNO(this->sleep_when_done_), YESNO(this->partial_updating_), this->full_update_every_);
      |                                        ^~~~~
*** [.pioenvs/test-screen/src/esphome/components/it8951e/it8951e.cpp.o] Error 1
```